### PR TITLE
Document Tag Typing

### DIFF
--- a/src/python_wrapper/cvldoc_parser.pyi
+++ b/src/python_wrapper/cvldoc_parser.pyi
@@ -3,7 +3,7 @@ from os import PathLike
 from typing import Any, Dict, List, Optional, Union
 
 class DocumentationTag:
-    kind: str
+    kind: TagKind
     description: str
     def param_name_and_description(self) -> Optional[tuple[str, str]]: ...
 


### PR DESCRIPTION

This PR changes the Python wrapper typing from `str` to `TagKind`. Example from https://github.com/Certora/cvldocTool/blob/master/tests/customer_code/GovernorPreventLateQuorum-expected.json

```python
In [22]: a = next(x for x in elements if x.element_name() == "proposalNotCreatedEffects")
In [23]: a.doc[0].kind
Out[23]: TagKind.Notice
```